### PR TITLE
Fix the docker_insecureregistry variable name

### DIFF
--- a/templates/default/docker.erb
+++ b/templates/default/docker.erb
@@ -3,5 +3,5 @@
 OPTIONS='--selinux-enabled<% if @docker_basedir -%> -g <%= @docker_basedir %><% end -%>'
 DOCKER_CERT_PATH=/etc/docker
 <% if @docker_registry -%>ADD_REGISTRY='--add-registry <%= @docker_registry %>'<% end -%>
-<% if @docker_insecureregistry -%>INSECURE_REGISTRY='--insecure-registry <%= @docker_registry %>'<% end -%>
+<% if @docker_insecureregistry -%>INSECURE_REGISTRY='--insecure-registry <%= @docker_insecureregistry %>'<% end -%>
 DOCKER_TMPDIR=<% if @docker_basedir -%><%= @docker_basedir %><% end -%>/tmp


### PR DESCRIPTION
`docker_registry` seems to injected into both `ADD_REGISTRY` and `INSECURE_REGISTRY`.
It doesn't allow for specifying a separate insecure registry.